### PR TITLE
conf: add help target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,40 +7,41 @@ PIP := pip
 # Rules
 .PHONY: install-backend install-tests run-backend run-tests clean act-list act-run act-help
 
-install-backend:
+install-backend: ## Install backend Python dependencies from backend/requirements.txt
 	@echo "Installing backend dependencies..."
 	@$(PIP) install -r backend/requirements.txt
 
-install-tests:
+install-tests: ## Install test dependencies from tests/requirements.txt
 	@echo "Installing test dependencies..."
 	@$(PIP) install -r tests/requirements.txt
 
-run-backend:
+run-backend: ## Start the backend server (backend/app.py)
 	@echo "Running the backend..."
 	@$(PYTHON) backend/app.py
 
-run-tests:
+run-tests: ## Execute BDD tests via tests/run_bdd_tests.py
 	@echo "Running BDD tests..."
 	@$(PYTHON) tests/run_bdd_tests.py
 
-clean:
+clean: ## Remove __pycache__ dirs and .pyc files
 	@echo "Cleaning temporary files..."
 	@find . -type d -name __pycache__ -exec rm -r {} +
 	@find . -type f -name '*.pyc' -delete
 
 # act - GitHub Actions local runner
-act-list:
+act-list: ## List available GitHub Actions workflows (act -l)
 	@echo "Listing available workflows..."
 	@act -l
 
-act-run:
+act-run: ## Run GitHub Actions workflow locally on push event (act push)
 	@echo "Running workflow locally with act..."
 	@act push --verbose
 
-act-help:
-	@echo "Available commands for act:"
-	@echo "  make act-list  - Lists all available workflows"
-	@echo "  make act-run   - Runs the push workflow locally"
-	@echo ""
-	@echo "Requirement: Docker Desktop must be running"
-	@echo "act installation: https://github.com/nektos/act"
+help: ## Show this help screen
+	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
+	@echo ''
+	@echo 'Available targets are:'
+	@echo ''
+	@grep -E '^[ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@echo ''


### PR DESCRIPTION
Adding a `help` target so that we don't need to write `*-help` targets ourselves.

Tested:

```
❯ make help
Usage: make <OPTIONS> ... <TARGETS>

Available targets are:

install-backend      Install backend Python dependencies from backend/requirements.txt
install-tests        Install test dependencies from tests/requirements.txt
run-backend          Start the backend server (backend/app.py)
run-tests            Execute BDD tests via tests/run_bdd_tests.py
clean                Remove __pycache__ dirs and .pyc files
act-list             List available GitHub Actions workflows (act -l)
act-run              Run GitHub Actions workflow locally on push event (act push)
help                 Show this help screen
```