### PR TITLE
add bind-mount configuration to .actrc to persist JUnit reports

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -7,5 +7,10 @@
 # Set container architecture
 --container-architecture linux/amd64
 
+# Bind-mount the current working directory into the container as /github/workspace.
+# This ensures files written by the container (e.g. JUnit XML reports under
+# reports/junit/) are persisted on the host after act finishes.
+--bind
+
 # Verbose output for debugging (remove if too noisy)
 #--verbose

--- a/.github/workflows/ci_example.yml
+++ b/.github/workflows/ci_example.yml
@@ -54,7 +54,7 @@ jobs:
         run: pip install -r backend/requirements.txt
 
       - name: Install frontend dependencies
-        run: npm install
+        run: npm ci
         working-directory: frontend
 
       # ── 3. Call the framework — DATABASE_URL is inherited from the job env ──

--- a/framework.yml
+++ b/framework.yml
@@ -17,7 +17,7 @@ installation:
 
     - name: Install Web deps
       path: frontend
-      command: npm install
+      command: npm ci
       service: web
 
     - name: Install Test deps


### PR DESCRIPTION
This pull request introduces improvements to local development and CI reliability by updating dependency installation commands and enhancing container file persistence. The main changes are grouped into improvements for CI consistency and enhancements to local development workflows.

**CI consistency improvements:**

* Changed the frontend dependency installation command from `npm install` to `npm ci` in both `.github/workflows/ci_example.yml` and `framework.yml` to ensure reproducible and faster installs in CI environments. (`.github/workflows/ci_example.yml` [[1]](diffhunk://#diff-bb82de59c68ce7dabeada61328f3c8cb47555cc0ca03d3fe6ffc0e64604584ffL57-R57) `framework.yml` [[2]](diffhunk://#diff-bd57e3d1792ecd6182a37b0cedf787769ed56a51cd3053f827f6603472943877L20-R20)

**Local development workflow enhancements:**

* Added the `--bind` option to `.actrc` to bind-mount the current working directory into the container, ensuring files written by the container are persisted on the host after running `act`. (`.actrc` [.actrcR10-R14](diffhunk://#diff-0f9b69d0391b61650a048594633a4008033be2e529ad90f15204a5e3d6637ec0R10-R14))