### PR TITLE
move behave dependency to the root requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 # el framework (bdd_framework.py). Las dependencias de cada servicio
 # están en sus respectivos directorios.
 
+behave==1.2.6
 PyYAML==6.0.1
 
 # Instalación completa del proyecto:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,6 @@
 # Testing Dependencies
 # =====================
 
-behave==1.2.6
 requests==2.31.0
 
 # Instalación:


### PR DESCRIPTION
This pull request makes a minor update to the `tests/requirements.txt` file by removing the `behave` testing dependency. This simplifies the test requirements and may indicate that `behave` is no longer needed for the test suite.