### PR TITLE
57 allow configurable python version in the framework

### DIFF
--- a/.github/workflows/ci_example.yml
+++ b/.github/workflows/ci_example.yml
@@ -126,3 +126,10 @@ jobs:
         uses: ./ #LukenLarra/RedHat-BDD-Framework@main
         with:
           service: "movies-api"
+          python_version: "3.12"
+
+          # Optional inputs (showing their default values for reference):
+          # bdd_config: "framework.yml"
+          # artifacts_log_dir: "junit"
+          # test_requirements: ""
+          # service_package: ""

--- a/README.md
+++ b/README.md
@@ -139,9 +139,11 @@ jobs:
       - uses: LukenLarra/RedHat-BDD-Framework@main
         with:
           service: "my-service"
+          # python_version: "3.12"                # optional, lets uv build the venv using a specific python version
           # bdd_config: "framework.yml"           # optional, default: framework.yml
           # artifacts_log_dir: "junit"            # optional, default: junit
           # test_requirements: "tests/requirements.txt"  # optional, see below
+          # service_package: "."                  # optional, install an importable package into the framework venv
 ```
 
 > **Tip:** The `services:` health check guarantees the database is fully ready before step 1 runs — no manual wait loops needed.
@@ -207,6 +209,7 @@ In your CI workflow, you must:
 - Define global environment variables such as `DATABASE_URL` (or the variable your stack uses).
 - Ensure all paths in your configuration file exist and are accessible to the framework.
 - If your step files require additional dependencies, provide a `requirements.txt` and pass it as the `test_requirements` input to the framework.
+- The framework runs Python-based BDD tests. You can specify the exact Python version to use for tests by passing the `python_version` input (e.g., `python_version: "3.12"`). If omitted, it will fall back to the environment's default Python.
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,12 @@ inputs:
       importable by the step files). Leave empty for non-Python services.
     required: false
     default: ""
+  python_version:
+    description: >
+      Python version to use for the BDD testing environment (e.g., '3.12').
+      If empty, uses the runner's default Python.
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -45,7 +51,11 @@ runs:
         fi
         echo "BDD_VENV_PATH=${BDD_VENV}" >> "$GITHUB_ENV"
         command -v uv > /dev/null 2>&1 || python -m pip install uv --quiet
-        uv venv "${BDD_VENV}"
+        if [[ -n "${{ inputs.python_version }}" ]]; then
+          uv venv --python "${{ inputs.python_version }}" "${BDD_VENV}"
+        else
+          uv venv "${BDD_VENV}"
+        fi
         uv pip install --quiet \
           --python "${BDD_VENV}/bin/python" \
           -r "${{ github.action_path }}/requirements.txt" \

--- a/bdd_framework.py
+++ b/bdd_framework.py
@@ -233,10 +233,9 @@ class BDDFramework:
         if extra_args:
             cmd_parts.extend(extra_args)
 
-        custom_env = tests_config.get("env") or {}
-        # Ensure that all values are strings, as required by subprocess.env
-        custom_env_str = {str(k): str(v) for k, v in custom_env.items()}
-        env = {**custom_env_str, **os.environ}
+        # Construir env con orden correcto — framework.yml tiene prioridad sobre os.environ
+        custom_env_str = {str(k): str(v) for k, v in (tests_config.get("env", {}) or {}).items()}
+        env = {**os.environ, **custom_env_str}
 
         try:
             # Run tests in the same process to see real-time output

--- a/bdd_framework.py
+++ b/bdd_framework.py
@@ -233,7 +233,10 @@ class BDDFramework:
         if extra_args:
             cmd_parts.extend(extra_args)
 
-        env = {**tests_config.get("env", {}), **os.environ}
+        custom_env = tests_config.get("env") or {}
+        # Ensure that all values are strings, as required by subprocess.env
+        custom_env_str = {str(k): str(v) for k, v in custom_env.items()}
+        env = {**custom_env_str, **os.environ}
 
         try:
             # Run tests in the same process to see real-time output


### PR DESCRIPTION
This pull request introduces support for specifying the Python version used in the BDD testing environment, improving flexibility and reproducibility for Python-based services. The changes include updates to the GitHub Action, documentation, and environment handling to make it clear and easy to select a Python version for your tests.

**Python version selection support:**

* Added a new optional `python_version` input to the GitHub Action (`action.yml`), allowing users to specify which Python version to use for the BDD test environment. If omitted, the runner's default Python is used.
* Updated the action's workflow logic to use the specified Python version when creating the virtual environment with `uv venv`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R54-R58) [[2]](diffhunk://#diff-bb82de59c68ce7dabeada61328f3c8cb47555cc0ca03d3fe6ffc0e64604584ffR129-R135)

**Documentation updates:**

* Updated `README.md` to document the new `python_version` input, including usage examples and clarifying its effect in the workflow. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R142-R146) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R212)

**Environment variable handling:**

* Fixed environment variable precedence in `_run_tests` so that variables defined in `framework.yml` correctly override those from `os.environ`.