### PR TITLE
Allow multiple features in @file.txt to generate a single --include argument

### DIFF
--- a/redhat_bdd_framework/cli.py
+++ b/redhat_bdd_framework/cli.py
@@ -219,8 +219,12 @@ class BDDFramework:
     def _build_include_args(
         self, feature_targets: List[str], tests_path: Path, cwd: Path
     ) -> List[str]:
-        """Convert explicit feature paths into behave --include filter arguments."""
-        include_args = []
+        """Convert explicit feature paths into a single behave --include filter argument.
+
+        behave's --include uses `store` (not `append`), so multiple flags overwrite each
+        other. All patterns are combined into one regex with | so every target is matched.
+        """
+        patterns = []
         cwd_resolved = cwd.resolve(strict=False)
 
         for feature in feature_targets:
@@ -236,9 +240,11 @@ class BDDFramework:
             except ValueError:
                 pattern = re.escape(feature_path.name)
 
-            include_args.append(f"--include={pattern}")
+            patterns.append(pattern)
 
-        return include_args
+        if not patterns:
+            return []
+        return [f"--include={'|'.join(patterns)}"]
 
     def _prepare_behave_command(
         self,

--- a/tests/test_cli_runtime_paths.py
+++ b/tests/test_cli_runtime_paths.py
@@ -71,6 +71,61 @@ class TestBDDCliRuntimePaths(unittest.TestCase):
             )
             self.assertFalse(any(arg.startswith("@") for arg in args))
 
+    def test_multiple_features_in_txt_produce_single_include_with_or(self):
+        """Multiple features in @file.txt must generate one --include with | not N separate flags.
+
+        behave's --include uses argparse `store` action, so each flag overwrites the
+        previous one. Passing N separate --include flags would silently drop all but
+        the last feature.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+
+            features_root = root / "features"
+            features_root.mkdir(parents=True)
+            for name in ("alpha.feature", "beta.feature", "gamma.feature"):
+                (features_root / name).write_text(f"Feature: {name}\n", encoding="utf-8")
+
+            test_list_dir = root / "test_list"
+            test_list_dir.mkdir()
+            txt_file = test_list_dir / "suite.txt"
+            txt_file.write_text(
+                "features/alpha.feature\nfeatures/beta.feature\nfeatures/gamma.feature\n",
+                encoding="utf-8",
+            )
+
+            config = {
+                "tests": {
+                    "enabled": True,
+                    "path": ".",
+                    "command": "python -m behave @test_list/suite.txt --format pretty",
+                    "bdd": {"features": "features"},
+                }
+            }
+
+            config_path = root / "framework.yml"
+            config_path.write_text(yaml.dump(config), encoding="utf-8")
+
+            framework = BDDFramework(str(config_path))
+
+            with patch("redhat_bdd_framework.cli.subprocess.run") as mock_run:
+                mock_proc = Mock()
+                mock_proc.returncode = 0
+                mock_run.return_value = mock_proc
+                framework.run()
+
+            args = mock_run.call_args[0][0]
+            include_args = [a for a in args if a.startswith("--include=")]
+
+            self.assertEqual(
+                len(include_args), 1, f"Expected exactly one --include, got: {include_args}"
+            )
+            pattern = include_args[0].split("=", 1)[1]
+            self.assertIn("alpha", pattern)
+            self.assertIn("beta", pattern)
+            self.assertIn("gamma", pattern)
+            self.assertIn("|", pattern)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request fixes how multiple feature files are passed to behave's `--include` argument, ensuring that all specified features are included in a single regex pattern instead of using multiple `--include` flags, which would silently drop all but the last feature. It also adds a new test to verify this behavior.

**Behavior correction for feature inclusion:**

* Updated `_build_include_args` in `redhat_bdd_framework/cli.py` to combine multiple feature patterns into a single `--include` argument using regex alternation (`|`), instead of generating multiple `--include` flags. This ensures all features are matched as intended, since behave only honors the last `--include` flag due to its use of the `store` action in argparse.

**Testing improvements:**

* Added `test_multiple_features_in_txt_produce_single_include_with_or` in `tests/test_cli_runtime_paths.py` to verify that multiple features listed in a file result in a single `--include` argument with all patterns joined by `|`, ensuring correct behavior and preventing silent test exclusion.