### PR TITLE
Improve tag management in context and update AI testing steps

### DIFF
--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -124,11 +124,14 @@ def reset_test_database(context):
 
 
 def _ui_tag_active(context) -> bool:
-    runner = getattr(context, "_runner", None)
-    tag_matcher = getattr(runner.config, "tags", None) if runner else None
-    if tag_matcher is None:
+    try:
+        runner = getattr(context, "_runner", None)
+        tag_matcher = getattr(runner.config, "tags", None) if runner else None
+        if tag_matcher is None:
+            return True
+        return tag_matcher.check(["ui"])
+    except (AttributeError, TypeError):
         return True
-    return tag_matcher.check(["ui"])
 
 
 def before_all(context):

--- a/tests/features/frontend_ai.feature
+++ b/tests/features/frontend_ai.feature
@@ -11,5 +11,5 @@ Feature: Validaciones E2E del Frontend con IA
   Scenario: Rellenar el formulario para interactuar con la web
     Given the frontend is running
     When I open the frontend homepage
-    When the AI acts on the page to "fill the add movie form with title 'Interstellar', year '2014', director 'Christopher Nolan' and click the submit button"
-    Then the AI visually confirms that "the movie 'Interstellar' appears in the movie catalog list"
+    When the AI acts on the page to "fill the add movie form with title 'Pirates of the Caribbean', year '2003', director 'Gore Verbinski' and click the submit button"
+    Then the AI visually confirms that "the movie 'Pirates of the Caribbean' appears in the movie catalog list"

--- a/tests/features/steps/frontend_steps.py
+++ b/tests/features/steps/frontend_steps.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import re
 import time
@@ -55,24 +56,44 @@ async def run_mcp_agent(
         "never use 'spinbutton' or other ARIA roles not in: textbox, checkbox, radio, combobox, slider.\n"
     )
 
+    action_prompt = base_prompt + (
+        "Your task is to PERFORM AN ACTION. "
+        "Once the action is complete and you have visually verified success, "
+        "return exactly the word DONE. Do not ask for user input. "
+        "Do NOT call browser_close at any point."
+    )
+
+    # Verification: Python drives navigation + snapshot so timing is reliable.
+    # The LLM only reasons about the snapshot text — no tool use needed.
     if is_condition:
-        system_prompt = base_prompt + (
-            "Your task is to VERIFY A CONDITION.\n"
-            "Use only browser_navigate and browser_snapshot to inspect the page. "
-            "Do NOT use browser_evaluate, browser_console_messages, or any other tools.\n"
-            "Once you have enough information, output ONLY a raw JSON object — "
-            "no markdown, no preamble, no explanation:\n"
-            '{"confirmed": true/false, "reason": "<one-line explanation>"}'
+        await session.call_tool("browser_navigate", arguments={"url": url})
+        await asyncio.sleep(3)  # allow async JS (fetchMovies) to complete
+        snap_result = await session.call_tool("browser_snapshot", arguments={})
+        page_snapshot = snap_result.content[0].text if snap_result.content else "(empty snapshot)"
+
+        verify_messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a web test verifier. Analyze the page accessibility snapshot and verify the condition. "
+                    "Output ONLY a raw JSON object — no markdown, no preamble, no explanation:\n"
+                    '{"confirmed": true/false, "reason": "<one-line explanation>"}'
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Page snapshot:\n{page_snapshot}\n\nCondition to verify: {task}",
+            },
+        ]
+        verify_response = openai_client.chat.completions.create(
+            model="meta-llama/llama-4-scout-17b-16e-instruct",
+            messages=verify_messages,
+            temperature=0.0,
         )
-    else:
-        system_prompt = base_prompt + (
-            "Your task is to PERFORM AN ACTION. "
-            "Once the action is complete and you have visually verified success, "
-            "return exactly the word DONE. Do not ask for user input."
-        )
+        return verify_response.choices[0].message.content or ""
 
     messages = [
-        {"role": "system", "content": system_prompt},
+        {"role": "system", "content": action_prompt},
         {"role": "user", "content": f"URL: {url}\nTask: {task}"},
     ]
 


### PR DESCRIPTION
This pull request updates the frontend E2E testing framework to improve reliability and clarity in how UI conditions are verified versus actions performed. The most important changes include a clearer separation of test agent behaviors for actions and conditions, improved snapshot-based verification, and minor test data updates.

**Test agent behavior improvements:**

* The `run_mcp_agent` function in `frontend_steps.py` now separates logic for performing actions and verifying conditions. For condition verification, navigation and snapshotting are handled in Python for more reliable timing, and the LLM is only used to analyze the resulting snapshot.
* The system prompt for actions is clarified to prevent the agent from closing the browser and to ensure it only returns "DONE" after successful visual verification.

**Test reliability and clarity:**

* When verifying conditions, the LLM is now given a snapshot of the page and asked to output a raw JSON object confirming the condition, ensuring more deterministic and explainable results.

**Minor improvements and updates:**

* The scenario in `frontend_ai.feature` was updated to use a different movie ("Pirates of the Caribbean" instead of "Interstellar") for the add-and-verify test, keeping test data fresh.
* Added an import for `asyncio` in `frontend_steps.py` to support the new asynchronous snapshot logic.
* The `_ui_tag_active` helper in `environment.py` is now more robust, defaulting to `True` if any attribute errors occur when checking tags.